### PR TITLE
updated environment sdk dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [0.1.6]
+* Updated environment sdk dependency
+
 ## [0.1.5]
 * Added `step` paramater for integer picker
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,11 @@
 name: numberpicker
-version: 0.1.5
+version: 0.1.6
 description: NumberPicker is a widget allowing user to choose numbers by scrolling spinners.
 author: Marcin Szalek <marcinszalek1@gmail.com>
 homepage: https://github.com/MarcinusX/NumberPicker
 
 environment:
-  sdk: ">=1.23.0 <2.0.0"
+  sdk: ">=2.0.0-dev.58.0 <3.0.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
recent versions of flutter have updated the dart SDK version, i.e. `The current Dart SDK version is 2.1.0-dev.0.0.flutter-be6309690f.`, and the current constraints in `pubspec.yaml` give the error: `Because markerdowner depends on numberpicker from git which requires SDK version >=1.23.0 <2.0.0, version solving failed.`

This PR is a fix for this constraint issue