### PR TITLE
Add zeroPad config for integer numberpickers

### DIFF
--- a/lib/numberpicker.dart
+++ b/lib/numberpicker.dart
@@ -26,6 +26,7 @@ class NumberPicker extends StatelessWidget {
     this.listViewWidth = DEFAULT_LISTVIEW_WIDTH,
     this.step = 1,
     this.infiniteLoop = false,
+    this.zeroPad = false,
   })
       : assert(initialValue != null),
         assert(minValue != null),
@@ -80,6 +81,7 @@ class NumberPicker extends StatelessWidget {
         step = 1,
         integerItemCount = maxValue.floor() - minValue.floor() + 1,
         infiniteLoop = false,
+        zeroPad = false,
         super(key: key);
 
   ///called when selected value changes
@@ -125,6 +127,9 @@ class NumberPicker extends StatelessWidget {
 
   ///Repeat values infinitely
   final bool infiniteLoop;
+
+  ///Pads displayed integer values up to the length of maxValue
+  final bool zeroPad;
 
   ///Amount of items
   final int integerItemCount;
@@ -204,10 +209,14 @@ class NumberPicker extends StatelessWidget {
 
             bool isExtra = index == 0 || index == listItemCount - 1;
 
+            String displayValue = zeroPad
+              ? value.toString().padLeft(maxValue.toString().length, '0')
+              : value.toString();
+
             return isExtra
                 ? new Container() //empty first and last element
                 : new Center(
-              child: new Text(value.toString(), style: itemStyle),
+              child: new Text(displayValue, style: itemStyle),
             );
           },
         ),
@@ -275,8 +284,12 @@ class NumberPicker extends StatelessWidget {
             final TextStyle itemStyle =
             value == selectedIntValue ? selectedStyle : defaultStyle;
 
+            String displayValue = zeroPad
+              ? value.toString().padLeft(maxValue.toString().length, '0')
+              : value.toString();
+
             return new Center(
-              child: new Text(value.toString(), style: itemStyle),
+              child: new Text(displayValue, style: itemStyle),
             );
           },
         ),
@@ -425,6 +438,7 @@ class NumberPickerDialog extends StatefulWidget {
   final Widget cancelWidget;
   final int step;
   final bool infiniteLoop;
+  final bool zeroPad;
 
   ///constructor for integer values
   NumberPickerDialog.integer({
@@ -435,6 +449,7 @@ class NumberPickerDialog extends StatefulWidget {
     this.titlePadding,
     this.step = 1,
     this.infiniteLoop = false,
+    this.zeroPad = false,
     Widget confirmWidget,
     Widget cancelWidget,
   })
@@ -458,7 +473,8 @@ class NumberPickerDialog extends StatefulWidget {
         cancelWidget = cancelWidget ?? new Text("CANCEL"),
         initialIntegerValue = -1,
         step = 1,
-        infiniteLoop = false;
+        infiniteLoop = false,
+        zeroPad = false;
 
   @override
   State<NumberPickerDialog> createState() =>
@@ -496,6 +512,7 @@ class _NumberPickerDialogControllerState extends State<NumberPickerDialog> {
         maxValue: widget.maxValue,
         step: widget.step,
         infiniteLoop: widget.infiniteLoop,
+        zeroPad: widget.zeroPad,
         onChanged: _handleValueChanged,
       );
     }

--- a/test/integer_infinite_numberpicker_test.dart
+++ b/test/integer_infinite_numberpicker_test.dart
@@ -87,6 +87,17 @@ void main() {
         expectedValue: 23,
         animateToItself: true);
   });
+
+  testWidgets('Zero pad works', (WidgetTester tester) async {
+    await _testNumberPicker(
+        tester: tester,
+        minValue: 0,
+        maxValue: 10,
+        initialValue: 9,
+        zeroPad: true,
+        scrollBy: 1,
+        expectedDisplayValues: ['09', '10', '00']);
+  });
 }
 
 Future<NumberPicker> _testNumberPicker(
@@ -94,9 +105,11 @@ Future<NumberPicker> _testNumberPicker(
     int minValue,
     int maxValue,
     int initialValue,
+    bool zeroPad = false,
     int scrollBy,
     int step = 1,
     int expectedValue,
+    List<String> expectedDisplayValues,
     bool animateToItself = false}) async {
   int value = initialValue;
   NumberPicker picker;
@@ -109,6 +122,7 @@ Future<NumberPicker> _testNumberPicker(
         maxValue: maxValue,
         step: step,
         infiniteLoop: true,
+        zeroPad: zeroPad,
         onChanged: (newValue) => setState(() => value = newValue),
       );
       return MaterialApp(
@@ -123,14 +137,23 @@ Future<NumberPicker> _testNumberPicker(
   await _scrollNumberPicker(Offset(0.0, 0.0), tester, scrollBy);
   await tester.pumpAndSettle();
 
-  expect(value, equals(expectedValue));
+  if (expectedValue != null) {
+    expect(value, equals(expectedValue));
 
-  if (animateToItself) {
-    expect(picker.selectedIntValue, equals(expectedValue));
-    await picker.animateInt(picker.selectedIntValue);
-    await tester.pumpAndSettle();
-    expect(picker.selectedIntValue, equals(expectedValue));
+    if (animateToItself) {
+      expect(picker.selectedIntValue, equals(expectedValue));
+      await picker.animateInt(picker.selectedIntValue);
+      await tester.pumpAndSettle();
+      expect(picker.selectedIntValue, equals(expectedValue));
+    }
   }
+
+  if (expectedDisplayValues != null) {
+    for (String displayValue in expectedDisplayValues) {
+      expect(find.text(displayValue), findsOneWidget);
+    }
+  }
+
   return picker;
 }
 

--- a/test/integer_numberpicker_test.dart
+++ b/test/integer_numberpicker_test.dart
@@ -89,6 +89,17 @@ void main() {
         expectedValue: 23,
         animateToItself: true);
   });
+
+  testWidgets('Zero pad works', (WidgetTester tester) async {
+    await _testNumberPicker(
+        tester: tester,
+        minValue: 0,
+        maxValue: 10,
+        initialValue: 2,
+        zeroPad: true,
+        scrollBy: 1,
+        expectedDisplayValues: ['02', '03', '04']);
+  });
 }
 
 Future<NumberPicker> _testNumberPicker(
@@ -96,9 +107,11 @@ Future<NumberPicker> _testNumberPicker(
     int minValue,
     int maxValue,
     int initialValue,
+    bool zeroPad = false,
     int scrollBy,
     int step = 1,
     int expectedValue,
+    List<String> expectedDisplayValues,
     bool animateToItself = false}) async {
   int value = initialValue;
   NumberPicker picker;
@@ -110,6 +123,7 @@ Future<NumberPicker> _testNumberPicker(
         minValue: minValue,
         maxValue: maxValue,
         step: step,
+        zeroPad: zeroPad,
         onChanged: (newValue) => setState(() => value = newValue),
       );
       return MaterialApp(
@@ -124,14 +138,23 @@ Future<NumberPicker> _testNumberPicker(
   await _scrollNumberPicker(Offset(0.0, 0.0), tester, scrollBy);
   await tester.pumpAndSettle();
 
-  expect(value, equals(expectedValue));
+  if (expectedValue != null) {
+    expect(value, equals(expectedValue));
 
-  if (animateToItself) {
-    expect(picker.selectedIntValue, equals(expectedValue));
-    await picker.animateInt(picker.selectedIntValue);
-    await tester.pumpAndSettle();
-    expect(picker.selectedIntValue, equals(expectedValue));
+    if (animateToItself) {
+      expect(picker.selectedIntValue, equals(expectedValue));
+      await picker.animateInt(picker.selectedIntValue);
+      await tester.pumpAndSettle();
+      expect(picker.selectedIntValue, equals(expectedValue));
+    }
   }
+
+  if (expectedDisplayValues != null) {
+    for (String displayValue in expectedDisplayValues) {
+      expect(find.text(displayValue), findsOneWidget);
+    }
+  }
+
   return picker;
 }
 


### PR DESCRIPTION
PR for #35

`zeroPad=true` zero pads displayed values up to the length of `maxValue`

![qemu-system-x86_64_2019-02-02_19-58-56](https://user-images.githubusercontent.com/226692/52162847-5d0e4400-2725-11e9-873f-ba3323c92092.png)