### PR TITLE
Allow supplying custom item builder to NumberPicker

### DIFF
--- a/lib/src/numberpicker.dart
+++ b/lib/src/numberpicker.dart
@@ -4,6 +4,13 @@ import 'package:flutter/services.dart';
 import 'package:infinite_listview/infinite_listview.dart';
 
 typedef TextMapper = String Function(String numberText);
+typedef NumberPickerCustomItemBuilder = Widget Function({
+  required BuildContext context,
+  required int index,
+  required int intValue,
+  required String displayValue,
+  required bool isSelected,
+});
 
 class NumberPicker extends StatefulWidget {
   /// Min value user can pick
@@ -57,6 +64,9 @@ class NumberPicker extends StatefulWidget {
 
   final bool infiniteLoop;
 
+  /// allows building custom item widget on the list
+  final NumberPickerCustomItemBuilder? customItemBuilder;
+
   const NumberPicker({
     Key? key,
     required this.minValue,
@@ -75,6 +85,7 @@ class NumberPicker extends StatefulWidget {
     this.zeroPad = false,
     this.textMapper,
     this.infiniteLoop = false,
+    this.customItemBuilder,
   })  : assert(minValue <= value),
         assert(value <= maxValue),
         super(key: key);
@@ -205,12 +216,24 @@ class _NumberPickerState extends State<NumberPicker> {
             index >= listItemsCount - additionalItemsOnEachSide);
     final itemStyle = value == widget.value ? selectedStyle : defaultStyle;
 
-    final child = isExtra
-        ? SizedBox.shrink()
-        : Text(
-            _getDisplayedValue(value),
-            style: itemStyle,
-          );
+    final customItemBuilder = widget.customItemBuilder;
+    Widget child = const SizedBox.shrink();
+    if (!isExtra) {
+      if (customItemBuilder != null) {
+        child = customItemBuilder(
+          context: context,
+          index: index,
+          intValue: value,
+          displayValue: _getDisplayedValue(value),
+          isSelected: value == widget.value,
+        );
+      } else {
+        child = Text(
+          _getDisplayedValue(value),
+          style: itemStyle,
+        );
+      }
+    }
 
     return Container(
       width: widget.itemWidth,

--- a/test/horizontal_numberpicker_test.dart
+++ b/test/horizontal_numberpicker_test.dart
@@ -1,3 +1,6 @@
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -13,6 +16,31 @@ void main() {
       scrollBy: 2,
       expectedValue: 7,
       axis: Axis.horizontal,
+    );
+  });
+
+  testWidgets('Integer small scroll up works + custom item builder',
+      (WidgetTester tester) async {
+    await testNumberPicker(
+      tester: tester,
+      minValue: 1,
+      maxValue: 10,
+      initialValue: 5,
+      scrollBy: 2,
+      expectedValue: 7,
+      axis: Axis.horizontal,
+      customItemBuilder: (
+              {required context,
+              required displayValue,
+              required index,
+              required intValue,
+              required isSelected}) =>
+          Text(
+        displayValue,
+        style: isSelected
+            ? TextStyle(color: Colors.amber)
+            : TextStyle(color: Colors.amberAccent),
+      ),
     );
   });
 

--- a/test/test_utils.dart
+++ b/test/test_utils.dart
@@ -26,6 +26,7 @@ Future<NumberPicker> testNumberPicker({
   required int expectedValue,
   Axis axis = Axis.vertical,
   Decoration? decoration,
+  NumberPickerCustomItemBuilder? customItemBuilder,
 }) async {
   int value = initialValue;
   late NumberPicker picker;
@@ -40,6 +41,7 @@ Future<NumberPicker> testNumberPicker({
               step: step,
               textMapper: textMapper,
               decoration: decoration,
+              customItemBuilder: customItemBuilder,
               onChanged: (newValue) => setState(() => value = newValue),
             )
           : NumberPicker(
@@ -50,6 +52,7 @@ Future<NumberPicker> testNumberPicker({
               step: step,
               textMapper: textMapper,
               decoration: decoration,
+              customItemBuilder: customItemBuilder,
               onChanged: (newValue) => setState(() => value = newValue),
             );
       return MaterialApp(


### PR DESCRIPTION
This allows further customization outside of standard behavior provided by this library. (a.k.a. as designer wanted it)