### PR TITLE
added GestureDetector to animate to value on tap

### DIFF
--- a/lib/src/numberpicker.dart
+++ b/lib/src/numberpicker.dart
@@ -212,11 +212,23 @@ class _NumberPickerState extends State<NumberPicker> {
             style: itemStyle,
           );
 
-    return Container(
-      width: widget.itemWidth,
-      height: widget.itemHeight,
-      alignment: Alignment.center,
-      child: child,
+    return GestureDetector(
+      behavior: HitTestBehavior.translucent,
+      onTapUp: isExtra
+          ? (_) => {}
+          : (_) {
+              _scrollController.animateTo(
+                (index - 1) * itemExtent,
+                duration: Duration(milliseconds: 300),
+                curve: Curves.easeOutCubic,
+              );
+            },
+      child: Container(
+        width: widget.itemWidth,
+        height: widget.itemHeight,
+        alignment: Alignment.center,
+        child: child,
+      ),
     );
   }
 


### PR DESCRIPTION
Finally, this should solve the issue: https://github.com/MarcinusX/NumberPicker/issues/31
When I fixed the issue some years ago I didn't even know what a pull request is, but times have changed.

It works perfectly fine in the example app, however all tests fail. 
It seems like the `GestureDetector` somehow interferes with the `TestGesture`.
I had a look into it for some hours now but couldn't figure out the problem. 
Maybe you have an idea as you are more into the code? 
Strangely, commenting out the line `behavior: HitTestBehavior.translucent,` makes the decimal_numberpicker_test succeed, maybe that can help if you have a look. 
However, we need that line so that clicking the empty area around the number will also trigger the onTapUp.