### PR TITLE
decoration-over-number-issue-fixed

### DIFF
--- a/lib/src/numberpicker.dart
+++ b/lib/src/numberpicker.dart
@@ -164,6 +164,11 @@ class _NumberPickerState extends State<NumberPicker> {
         },
         child: Stack(
           children: [
+            _NumberPickerSelectedItemDecoration(
+              axis: widget.axis,
+              itemExtent: itemExtent,
+              decoration: widget.decoration,
+            ),
             if (widget.infiniteLoop)
               InfiniteListView.builder(
                 scrollDirection: widget.axis,
@@ -181,11 +186,6 @@ class _NumberPickerState extends State<NumberPicker> {
                 itemBuilder: _itemBuilder,
                 padding: EdgeInsets.zero,
               ),
-            _NumberPickerSelectedItemDecoration(
-              axis: widget.axis,
-              itemExtent: itemExtent,
-              decoration: widget.decoration,
-            ),
           ],
         ),
       ),


### PR DESCRIPTION
**Description:**

This pull request resolves issue #146 by addressing the problem where the decoration was covering the number in the `NumberPicker` widget. The issue occurred because the decoration was placed as the last child in the stack, causing it to cover the other child and appear over the number text.

**Changes Made:**

To resolve this issue, I made the following changes:
- Moved the decoration to be the first child in the stack, ensuring it is positioned as the bottommost element.

**Testing:**

I have tested these changes by creating and running a Flutter app and confirming that the decoration no longer covers the number.

**Screenshots:**
<table align="center">
  <tr>
    <td align="center">Before</td>
    <td align="center">After</td>
  </tr>
  <tr>
    <td><img src="https://github.com/MarcinusX/NumberPicker/assets/62293473/e4118c61-62fe-4178-a8e8-762f691db862" height="400"></td>
    <td><img src="https://github.com/MarcinusX/NumberPicker/assets/62293473/a585d636-57bd-48a5-8f89-29cad044d61f" height="400"></td>
  </tr>
</table>

**Related Issue:**

This pull request is related to #146, I created the issue post a few weeks ago when I first used the numberpicker widget in a project and noticed the decoration problem. I had some time today so I decided to go through the source code and noticed that the issue could be fixed by simply rearranging the order of the widgets in the stack and moving the decoration to be the first child i.e the one that appears at the bottom.

**Note for Reviewers:**

I apologize if I have missed any steps, this is my first public contribution bug fix. Please review these changes and provide feedback or approval as needed. Thank you!
