### PR TITLE
Fix issue where decoration widget covers selected item in list

### DIFF
--- a/lib/src/numberpicker.dart
+++ b/lib/src/numberpicker.dart
@@ -164,6 +164,11 @@ class _NumberPickerState extends State<NumberPicker> {
         },
         child: Stack(
           children: [
+            _NumberPickerSelectedItemDecoration(
+              axis: widget.axis,
+              itemExtent: itemExtent,
+              decoration: widget.decoration,
+            ),
             if (widget.infiniteLoop)
               InfiniteListView.builder(
                 scrollDirection: widget.axis,
@@ -181,11 +186,6 @@ class _NumberPickerState extends State<NumberPicker> {
                 itemBuilder: _itemBuilder,
                 padding: EdgeInsets.zero,
               ),
-            _NumberPickerSelectedItemDecoration(
-              axis: widget.axis,
-              itemExtent: itemExtent,
-              decoration: widget.decoration,
-            ),
           ],
         ),
       ),


### PR DESCRIPTION
**Description:**

This pull request aims to fix an issue where, if the decoration value is set to a non-transparent widget (e.g., a solid red box), the selected value in the list gets completely covered by the decoration. The fix ensures that the selected value always remains visible above the decoration, regardless of its transparency.

**Summary of Changes**
Moved the _NumberPickerSelectedItemDecoration value to be generated before the list, ensuring that it appears underneath the list items.
This ensures that, whether the decoration is transparent or not, the selected item always appears above it.
**Motivation**
When using the library with a non-transparent decoration, the selected item in the list would be completely covered, affecting user experience. This change ensures that the selected item is always displayed clearly and correctly.

**How to Test**
Set the decoration for the widget to a non-transparent solid red box.
Verify that the selected value remains clearly visible above the decoration.
Change the decoration to other types (transparent, non-transparent) to test stability.